### PR TITLE
chore: adjust main camera for third-person view

### DIFF
--- a/Flight_sim Homework/Assets/Scenes/SampleScene.unity
+++ b/Flight_sim Homework/Assets/Scenes/SampleScene.unity
@@ -206,7 +206,7 @@ Transform:
   m_GameObject: {fileID: 330585543}
   serializedVersion: 2
   m_LocalRotation: {x: -0.087306865, y: 0.25755385, z: -0.26833752, w: 0.92414206}
-  m_LocalPosition: {x: 0.372, y: 3.863, z: 0.515}
+  m_LocalPosition: {x: -3.519, y: 5.155, z: -7.658}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []


### PR DESCRIPTION
This Pull Request updates the Main Camera's transform to provide a clear, third-person perspective of the aircraft.

**Key Changes:**
* Repositioned the Main Camera behind the 3D Spitfire model.
* Ensures the aircraft and its textures are fully visible during Play mode to meet the visual validation requirements of the prototype.